### PR TITLE
Remove frontend/dist from git tracking, add build script for Render

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,9 @@ out
 # Avatar pictures
 avatar_pictures/
 
+# Frontend build output (built by Render during deploy)
+frontend/dist/
+
 # DynamoDB Local files
 .dynamodb/
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "app.js",
   "scripts": {
     "start": "node BackEnd/app.js",
+    "build": "cd frontend && npm install && npm run build",
     "dev": "SET NODE_ENV=DEVELOPMENT& nodemon BackEnd/app.js",
     "prod": "SET NODE_ENV=PRODUCTION& node BackEnd/app.js",
     "seeder": "SET NODE_ENV=DEVELOPMENT& node BackEnd/seed/seeder.js",


### PR DESCRIPTION
## What this does

- Adds `frontend/dist/` to `.gitignore` so build artifacts are never committed again
- Adds a `build` script to `package.json` so Render can build the frontend automatically on every deploy

## Why

Previously, the built `frontend/dist/` folder was committed to git manually before every push. This caused noisy PRs full of minified machine-generated files and required a manual `npm run build` step locally.

## After merging — update Render settings

In your Render Web Service → Settings, change:

| Field | Value |
|---|---|
| **Build Command** | `npm install && npm run build` |
| **Start Command** | `node BackEnd/app.js` |
| **Root Directory** | (leave empty) |

From then on: push source code → Render builds + deploys automatically. No more manual builds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RtM6MeG3CSC67X5kYJG7NE)_